### PR TITLE
Remove Default impl and make resources available in Startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,13 @@
 Bevy Easy Config is a plugin that allows you to load config files easily and instantiate them as a resource.
 
 ## Usage
-First define the struct that you would like to load, and impl/derive the relevant traits:
+First define the struct that you would like to load, and derive the relevant traits:
 ```rust
 // Define the struct to load
 #[derive(Deserialize, Asset, Resource, Clone, TypePath)]
 struct Settings {
     some_keybind: KeyCode
 }
-
-// Default also needs to be implemented
-impl Default for Settings {
-    fn default() -> Self {
-        Self {
-            some_keybind: KeyCode::KeyW
-        }
-    }
-}
-
 ```
 The add it to your app:
 ```rust
@@ -34,6 +24,7 @@ fn main() {
             DefaultPlugins,
             EasyConfigPlugin::<Settings>::new("settings.ron"),
         ))
+        .add_systems(Update, some_random_function)
         .run();
 }
 ```
@@ -46,11 +37,6 @@ fn some_random_function(
     // ... Your awesome code here
 }
 ```
-
-## Notices
-Until the asset is loaded, when accessing the Settings resource, you will get the values from `Settings::default()`.
-As far as I know there isn't really a good way around this, so you will have to work with the default values for the
-first few ticks, until the asset is loaded. When the asset is loaded, it will automatically replace the default values.
 
 ## Compatible Bevy versions
 | `bevy_easy_config`    | `bevy`   |

--- a/assets/settings.ron
+++ b/assets/settings.ron
@@ -1,5 +1,5 @@
 Settings (
     // You can change this at runtime, and then save the file to hot reload.
     // You can try KeyW for W, KeyR for R, or any other valid KeyCode enum value.
-    action_keybind: KeyA
+    action_keybind: Space
 )

--- a/assets/settings.ron
+++ b/assets/settings.ron
@@ -1,5 +1,5 @@
 Settings (
     // You can change this at runtime, and then save the file to hot reload.
     // You can try KeyW for W, KeyR for R, or any other valid KeyCode enum value.
-    action_keybind: Space
+    action_keybind: KeyA
 )

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -22,7 +22,6 @@ fn main() {
     - Resource, 
     - Clone,
     - TypePath
-    All traits except default can simply be implemented with #[derive()] 
 */
 #[derive(Deserialize, Asset, Resource, Clone, TypePath)]
 struct Settings {

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -10,6 +10,7 @@ fn main() {
             // Adds the settings struct as a resource, and loads it from "assets/settings.ron"
             EasyConfigPlugin::<Settings>::new("settings.ron")
         ))
+        .add_systems(Startup, print_config_key)
         .add_systems(Update, print_on_keypress)
         .run();
 }
@@ -21,7 +22,6 @@ fn main() {
     - Resource, 
     - Clone,
     - TypePath
-    and it must also implement Default.
     All traits except default can simply be implemented with #[derive()] 
 */
 #[derive(Deserialize, Asset, Resource, Clone, TypePath)]
@@ -29,21 +29,11 @@ struct Settings {
     action_keybind: KeyCode
 }
 
-/*
-This is the default state that the struct will be loaded in.
 
-Until the Asset part of the struct is loaded properly,
-the struct will have the values that are implemented in default.
-
-When the asset is finished loading, the values from whatever file
-that is being loaded will replace the values from 'Default'
-*/
-impl Default for Settings {
-    fn default() -> Self {
-        Self {
-            action_keybind: KeyCode::Space
-        }
-    }
+fn print_config_key(
+    settings: Res<Settings>
+) {
+    println!("Settings loaded; current key: {:#?}", settings.action_keybind);
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ where
     let config_string = std::fs::read_to_string(config_path.as_path()).unwrap();
     let config_file: A = ron::from_str(&config_string).unwrap();
 
-    let config_file_handle: Handle<A> = asset_server.add(config_file.clone());
+    let config_file_handle: Handle<A> = asset_server.load(config_file_holder.path);
     config_file_holder.handle = Some(config_file_handle.clone());
 
     commands.insert_resource(config_file);


### PR DESCRIPTION
This pull request removes the requirement to derive Default on the config files, as well as making the resources that contains the config file, available in the Startup schedule, by moving the loading part to PreStartup